### PR TITLE
Fix mkdocs instant loading problem, close #2

### DIFF
--- a/.idea/mkdocs-open-in-new-tab.iml
+++ b/.idea/mkdocs-open-in-new-tab.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/mkdocs-open-in-new-tab.iml" filepath="$PROJECT_DIR$/.idea/mkdocs-open-in-new-tab.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
   <component name="ChangeListManager">
     <list default="true" id="f192e16d-e29a-44f9-8d9e-77455962a9b6" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/.idea/mkdocs-open-in-new-tab.iml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/modules.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -25,8 +31,14 @@
   "keyToString": {
     "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "WebServerToolWindowFactoryState": "false",
+    "git-widget-placeholder": "main",
     "last_opened_file_path": "/Users/kuba/Documents/git/kuba/mkdocs-open-in-new-tab",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }
@@ -71,6 +83,7 @@
       <updated>1679863072533</updated>
       <workItem from="1679863074113" duration="45000" />
       <workItem from="1679863123055" duration="4564000" />
+      <workItem from="1688131084288" duration="6131000" />
     </task>
     <servers />
   </component>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 <img src="https://img.shields.io/github/forks/JakubAndrysek/mkdocs-open-in-new-tab?style=flat-square">
 <img src="https://img.shields.io/github/issues/JakubAndrysek/mkdocs-open-in-new-tab?style=flat-square">
 <img src="https://static.pepy.tech/personalized-badge/mkdocs-open-in-new-tab?period=month&units=international_system&left_color=black&right_color=orange&left_text=Downloads">
-
-
 </p>
 
 This plugin adds JS code to open outgoing links and PDFs in a new tab.
@@ -67,8 +65,8 @@ Look at this source <a href="https://github.com/JakubAndrysek/mkdocs-open-in-new
 
 //open external links in a new window
 function external_new_window() {
-    for(var c = document.getElementsByTagName("a"), a = 0;a < c.length;a++) {
-        var b = c[a];
+    for(let c = document.getElementsByTagName("a"), a = 0;a < c.length;a++) {
+        let b = c[a];
         if(b.getAttribute("href") && b.hostname !== location.hostname) {
             b.target = "_blank";
             b.rel = "noopener";
@@ -78,9 +76,11 @@ function external_new_window() {
 //open PDF links in a new window
 function pdf_new_window ()
 {
-    if (!document.getElementsByTagName) return false;
-    var links = document.getElementsByTagName("a");
-    for (var eleLink=0; eleLink < links.length; eleLink ++) {
+    if (!document.getElementsByTagName) {
+      return false;
+    }
+    let links = document.getElementsByTagName("a");
+    for (let eleLink=0; eleLink < links.length; eleLink ++) {
     if ((links[eleLink].href.indexOf('.pdf') !== -1)||(links[eleLink].href.indexOf('.doc') !== -1)||(links[eleLink].href.indexOf('.docx') !== -1)) {
         links[eleLink].onclick =
         function() {
@@ -91,16 +91,26 @@ function pdf_new_window ()
     }
 }
 
-window.addEventListener("DOMContentLoaded", function() {
+function apply_rules() {
     external_new_window();
     pdf_new_window();
-});
+}
+
+if (typeof document$ !== "undefined") {
+    // compatibility with mkdocs-material's instant loading feature
+    // based on code from https://github.com/timvink/mkdocs-charts-plugin
+    // Copyright (c) 2021 Tim Vink - MIT License
+    // fixes [Issue #2](https://github.com/JakubAndrysek/mkdocs-open-in-new-tab/issues/2)
+    document$.subscribe(function() {
+        apply_rules();
+    })
+}
 ```
 </p>
 </details>
 
-## Known issues
-This extension does not work with mkdocs-material [navigation.instant](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading). JS could not be loaded when the page is loaded instantly. If you know how to fix it, please let me know. Issue is [here](https://github.com/JakubAndrysek/mkdocs-open-in-new-tab/issues/2).
+<!-- ## Known issues
+This extension does not work with mkdocs-material [navigation.instant](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading). JS could not be loaded when the page is loaded instantly. If you know how to fix it, please let me know. Issue is [here](https://github.com/JakubAndrysek/mkdocs-open-in-new-tab/issues/2). -->
 
 ## License
 

--- a/RelativeLink.md
+++ b/RelativeLink.md
@@ -1,3 +1,5 @@
 # Relative Link
 
 This is a relative link back to the [README](README.md).
+
+This is outgoing link to [Github](https://github.com/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,6 @@
 <img src="https://img.shields.io/github/forks/JakubAndrysek/mkdocs-open-in-new-tab?style=flat-square">
 <img src="https://img.shields.io/github/issues/JakubAndrysek/mkdocs-open-in-new-tab?style=flat-square">
 <img src="https://static.pepy.tech/personalized-badge/mkdocs-open-in-new-tab?period=month&units=international_system&left_color=black&right_color=orange&left_text=Downloads">
-
-
 </p>
 
 This plugin adds JS code to open outgoing links and PDFs in a new tab.
@@ -67,8 +65,8 @@ Look at this source <a href="https://github.com/JakubAndrysek/mkdocs-open-in-new
 
 //open external links in a new window
 function external_new_window() {
-    for(var c = document.getElementsByTagName("a"), a = 0;a < c.length;a++) {
-        var b = c[a];
+    for(let c = document.getElementsByTagName("a"), a = 0;a < c.length;a++) {
+        let b = c[a];
         if(b.getAttribute("href") && b.hostname !== location.hostname) {
             b.target = "_blank";
             b.rel = "noopener";
@@ -78,9 +76,11 @@ function external_new_window() {
 //open PDF links in a new window
 function pdf_new_window ()
 {
-    if (!document.getElementsByTagName) return false;
-    var links = document.getElementsByTagName("a");
-    for (var eleLink=0; eleLink < links.length; eleLink ++) {
+    if (!document.getElementsByTagName) {
+      return false;
+    }
+    let links = document.getElementsByTagName("a");
+    for (let eleLink=0; eleLink < links.length; eleLink ++) {
     if ((links[eleLink].href.indexOf('.pdf') !== -1)||(links[eleLink].href.indexOf('.doc') !== -1)||(links[eleLink].href.indexOf('.docx') !== -1)) {
         links[eleLink].onclick =
         function() {
@@ -91,16 +91,27 @@ function pdf_new_window ()
     }
 }
 
-window.addEventListener("DOMContentLoaded", function() {
+function apply_rules() {
     external_new_window();
     pdf_new_window();
-});
+}
+
+if (typeof document$ !== "undefined") {
+    // compatibility with mkdocs-material's instant loading feature
+    // based on code from https://github.com/timvink/mkdocs-charts-plugin
+    // Copyright (c) 2021 Tim Vink - MIT License
+    // fixes [Issue #2](https://github.com/JakubAndrysek/mkdocs-open-in-new-tab/issues/2)
+    document$.subscribe(function() {
+        apply_rules();
+        console.log("Applying rules");
+    })
+}
 ```
 </p>
 </details>
 
-## Known issues
-This extension does not work with mkdocs-material [navigation.instant](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading). JS could not be loaded when the page is loaded instantly. If you know how to fix it, please let me know. Issue is [here](https://github.com/JakubAndrysek/mkdocs-open-in-new-tab/issues/2).
+<!-- ## Known issues
+This extension does not work with mkdocs-material [navigation.instant](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading). JS could not be loaded when the page is loaded instantly. If you know how to fix it, please let me know. Issue is [here](https://github.com/JakubAndrysek/mkdocs-open-in-new-tab/issues/2). -->
 
 ## License
 

--- a/docs/RelativeLink.md
+++ b/docs/RelativeLink.md
@@ -1,3 +1,5 @@
 # Relative Link
 
 This is a relative link back to the [README](README.md).
+
+This is outgoing link to [Github](https://github.com/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ theme:
     - navigation.tracking
     - navigation.tabs
     - navigation.expand
+    # - navigation.instant for testing purposes
   icon:
     repo: fontawesome/brands/github
 

--- a/open_in_new_tab/js/open_in_new_tab.js
+++ b/open_in_new_tab/js/open_in_new_tab.js
@@ -3,8 +3,8 @@
 
 //open external links in a new window
 function external_new_window() {
-    for(var c = document.getElementsByTagName("a"), a = 0;a < c.length;a++) {
-        var b = c[a];
+    for(let c = document.getElementsByTagName("a"), a = 0;a < c.length;a++) {
+        let b = c[a];
         if(b.getAttribute("href") && b.hostname !== location.hostname) {
             b.target = "_blank";
             b.rel = "noopener";
@@ -14,9 +14,11 @@ function external_new_window() {
 //open PDF links in a new window
 function pdf_new_window ()
 {
-    if (!document.getElementsByTagName) return false;
-    var links = document.getElementsByTagName("a");
-    for (var eleLink=0; eleLink < links.length; eleLink ++) {
+    if (!document.getElementsByTagName) {
+      return false;
+    }
+    let links = document.getElementsByTagName("a");
+    for (let eleLink=0; eleLink < links.length; eleLink ++) {
     if ((links[eleLink].href.indexOf('.pdf') !== -1)||(links[eleLink].href.indexOf('.doc') !== -1)||(links[eleLink].href.indexOf('.docx') !== -1)) {
         links[eleLink].onclick =
         function() {
@@ -27,7 +29,17 @@ function pdf_new_window ()
     }
 }
 
-window.addEventListener("DOMContentLoaded", function() {
+function apply_rules() {
     external_new_window();
     pdf_new_window();
-});
+}
+
+if (typeof document$ !== "undefined") {
+    // compatibility with mkdocs-material's instant loading feature
+    // based on code from https://github.com/timvink/mkdocs-charts-plugin
+    // Copyright (c) 2021 Tim Vink - MIT License
+    // fixes [Issue #2](https://github.com/JakubAndrysek/mkdocs-open-in-new-tab/issues/2)
+    document$.subscribe(function() {
+        apply_rules();
+    })
+}

--- a/open_in_new_tab/plugin.py
+++ b/open_in_new_tab/plugin.py
@@ -6,12 +6,12 @@
 # PyPI: https://pypi.org/project/mkdocs-open-in-new-tab/
 # Inspired by: https://github.com/timvink/mkdocs-charts-plugin/tree/main
 
-import open_in_new_tab
 from mkdocs.plugins import BasePlugin
 from mkdocs.utils import copy_file
 import os
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+
 
 class OpenInNewTabPlugin(BasePlugin):
     def on_config(self, config, **kwargs):
@@ -22,8 +22,6 @@ class OpenInNewTabPlugin(BasePlugin):
         # Add pointer to open_in_new_tab.js file to extra_javascript
         # which is added to the output directory during on_post_build() event
         config["extra_javascript"].append("js/open_in_new_tab.js")
-
-
 
     def on_post_build(self, config):
         """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 # https://pypi.org/project/mkdocs-open-in-new-tab/
 setup(
     name='mkdocs-open-in-new-tab',
-    version='1.0.2',
+    version='1.0.3',
     description='MkDocs plugin to open outgoing links and PDFs in new tab.',
     long_description=readme(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Add support for instant loading - MkDocs Material.

Thanks to [mkdocs_charts_plugin](https://github.com/timvink/mkdocs-charts-plugin/blob/87789f5fe3a71d93fc9b1a97d9084ed666361e6f/mkdocs_charts_plugin/js/mkdocs-charts-plugin.js#L238-L246) plugin that supports that feature.

@timvink

Closes issue:
#2 - Does not work with material navigation.instant