### PR TITLE
New Feature: Exclude specified hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The plugin supports the following configuration option:
 
 - `add_icon:` (default: false)
     - If set to true, the plugin will add an icon next to external links.
+- `exclude_hosts` (list, default: empty)
+    - If the host of the link is included in the list, it will not be treated as an external link.
 
 
 ## Testing

--- a/open_in_new_tab/js/open_in_new_tab.js
+++ b/open_in_new_tab/js/open_in_new_tab.js
@@ -3,9 +3,12 @@
 
 // Open external links in a new window
 function external_new_window() {
+
+    const exclude_hosts = [];
+
     for(let c = document.getElementsByTagName("a"), a = 0; a < c.length; a++) {
         let b = c[a];
-        if(b.getAttribute("href") && b.host !== location.host) {
+        if(b.getAttribute("href") && b.host !== location.host && !exclude_hosts.includes(b.host)) {
             b.target = "_blank";
             b.rel = "noopener";
         }

--- a/open_in_new_tab/plugin.py
+++ b/open_in_new_tab/plugin.py
@@ -15,6 +15,7 @@ from mkdocs.utils import copy_file
 
 class OpenInNewTabPluginConfig(Config):
     add_icon = Type(bool, default=False)
+    exclude_hosts = Type(list, default=[])
 
 
 class OpenInNewTabPlugin(BasePlugin[OpenInNewTabPluginConfig]):
@@ -36,7 +37,17 @@ class OpenInNewTabPlugin(BasePlugin[OpenInNewTabPluginConfig]):
         See https://www.mkdocs.org/user-guide/plugins/#on_post_build.
         """
         site_dir = Path(config["site_dir"])
-        self.copy_asset("js/open_in_new_tab.js", site_dir)
+        js_asset_path = "js/open_in_new_tab.js"
+        self.copy_asset(js_asset_path, site_dir)
+        if self.config.exclude_hosts:
+            dest_path = site_dir / js_asset_path
+            exclude_hosts_str = ", ".join([f'"{i}"' for i in self.config.exclude_hosts])
+            dest_path.write_text(
+                dest_path.read_text().replace(
+                    "const exclude_hosts = [];",
+                    f"const exclude_hosts = [{exclude_hosts_str}];",
+                )
+            )
 
         if self.config.add_icon:
             self.copy_asset("css/open_in_new_tab.css", site_dir)

--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,19 @@ from setuptools import setup, find_packages
 
 
 def readme():
-    with open("README.md") as f:
+    with open("README.md", encoding="utf-8") as f:
         return f.read()
 
 
 def import_requirements():
     """Imports requirements from requirements.txt file."""
-    with open("requirements.txt") as f:
+    with open("requirements.txt", encoding="utf-8") as f:
         return f.read().splitlines()
 
 
 def import_dev_requirements():
     """Imports requirements from devdeps.txt file."""
-    with open("devdeps.txt") as f:
+    with open("devdeps.txt", encoding="utf-8") as f:
         return f.read().splitlines()
 
 


### PR DESCRIPTION
Add configuration option: `exclude_hosts` (list, default: empty)：

If the host of the link is included in the list, it will not be treated as an external link.

BTW: Errors happened during runing `setup.py` due to system encoding. Add encoding attributes in `open()` in it.